### PR TITLE
Silence byte compiler warnings for font-lock-syntactic-keywords 

### DIFF
--- a/mmm-region.el
+++ b/mmm-region.el
@@ -874,7 +874,7 @@ calls each respective submode's `syntax-propertize-function'."
                       (cond
                        (func
                         (funcall func beg end))
-                       (font-lock-syntactic-keywords
+                       ((bound-and-true-p font-lock-syntactic-keywords)
                         (let ((syntax-propertize-function nil))
                           (font-lock-fontify-syntactic-keywords-region beg end))))
                       (run-hook-with-args 'mmm-after-syntax-propertize-functions


### PR DESCRIPTION
The variable font-lock-syntactic-keywords is obsolete since Emacs 24.1.  Even if mmm-mode only supports Emacs 25.1 and forward it still has to handle submodes that still use it.

Silence the annoying byte compiler warning by checking if font-lock-syntactic-keywords is bound before using it.